### PR TITLE
Bugfix/get movie info

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import re
 import os
 import logging
 from datetime import datetime
+from utils import get_datetime_info, clean_movie_name_for_api
 from dal import movie_data_normalizer, movie_links_endpoint, movie_endpoint, get_movie_imdb_info, normalized_imdb_info, user_data_log
 from telegram import Update, InlineQueryResultArticle, InputTextMessageContent, InlineKeyboardMarkup, InlineKeyboardButton
 from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters, InlineQueryHandler, CallbackQueryHandler
@@ -60,13 +61,15 @@ async def inline_query(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     user = inline_query.from_user
     
     # Get DateTime Info
-    datetime_info = datetime.now()
-    year = datetime_info.year
-    month = datetime_info.month
-    day = datetime_info.day
-    hour = datetime_info.hour
-    minute = datetime_info.minute
-    second = datetime_info.second
+    datetime_info = get_datetime_info()
+    print(datetime_info)
+    year = datetime_info.get('year')
+    print(year)
+    month = datetime_info.get('month')
+    day = datetime_info.get('day')
+    hour = datetime_info.get('hour')
+    minute = datetime_info.get('minute')
+    second = datetime_info.get('second')
 
     user_data = (
         f"Query ID: {inline_query.id}\n"
@@ -93,7 +96,8 @@ async def button(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     elif data.startswith("info:"):
         final_result = list()
         movie_name = data.split(":")[1]
-        movie_info = get_movie_imdb_info(movie_name, API_KEY)
+        cleaned_movie_name = clean_movie_name_for_api(movie_name)
+        movie_info = get_movie_imdb_info(cleaned_movie_name, API_KEY)
         result = normalized_imdb_info(movie_info)
         
         for key, value in result.items():

--- a/utils.py
+++ b/utils.py
@@ -7,6 +7,24 @@ MOVIE_INFO_URL = 'https://www.omdbapi.com'
 BASE_URL = 'https://www.f2mex.ir'
 
 
+
+def clean_movie_name_for_api(movie_name: str) -> str:
+    """
+    Removes the year suffix (e.g., '-2024') from the movie name if present.
+
+    Args:
+        movie_name: str
+    
+    Returns:
+        str: Cleaned Movie name without the year suffix.
+    """
+
+    if len(movie_name) > 5 and movie_name[-5] == '-' and movie_name[-4:].isdigit():
+        return movie_name[-5:]
+    
+    return movie_name
+
+
 def get_datetime_info() -> Dict:
     """
     Getting Current Datetime Info

--- a/utils.py
+++ b/utils.py
@@ -20,7 +20,7 @@ def clean_movie_name_for_api(movie_name: str) -> str:
     """
 
     if len(movie_name) > 5 and movie_name[-5] == '-' and movie_name[-4:].isdigit():
-        return movie_name[-5:]
+        return movie_name[:-5]
     
     return movie_name
 
@@ -43,7 +43,7 @@ def get_datetime_info() -> Dict:
         'month': datetime_info.month,
         'day': datetime_info.day,
         'hour': datetime_info.hour,
-        'minut': datetime_info.minute,
+        'minute': datetime_info.minute,
         'second': datetime_info.second,
     }
 


### PR DESCRIPTION
third-party api could not process movies with published_date suffix
so we first create a function to normalize and clean movie_name
it means remove "-" plus 4 digits of published_year
and so small enhancements
like using get_dateime_info function from utils module

FIX #15